### PR TITLE
Fix mosaic 4 band bug and ground truth reprojection

### DIFF
--- a/seagrass/mosaic.py
+++ b/seagrass/mosaic.py
@@ -99,7 +99,7 @@ def return_s2_mosaic_projected_ground_truth(
         dst_transform=s2_transform,
         dst_crs=ground_truth_data.crs,
         dst_resolution=10,
-        resampling=Resampling.bilinear,
+        resampling=Resampling.nearest,
     )
 
     return s2_projected_ground_truth
@@ -146,6 +146,7 @@ def change_crs(data, src_crs, src_transform, dst_crs):
         np.ndarray: Raster reprojected to new coordinate system.
     """
     data_bounds = array_bounds(data.shape[1], data.shape[2], src_transform)
+    no_of_channels = data.shape[0]
 
     new_transform, width, height = calculate_default_transform(
         src_crs,
@@ -158,7 +159,7 @@ def change_crs(data, src_crs, src_transform, dst_crs):
 
     reprojected, transform = reproject(
         data,
-        np.zeros((4, width, height), dtype=np.float32),
+        np.zeros((no_of_channels, width, height), dtype=np.float32),
         src_transform=src_transform,
         src_crs=src_crs,
         src_nodata=None,


### PR DESCRIPTION
PR fixes the mosaic 4 band issues and prevents interpolation when reprojecting ground truth images. In the future, if the required ground truth data is continuous, then another patch will be applied to select a resampling type based on the detected ground truth data type.