### PR TITLE
Change Python version to 3.7 to work with Modulos

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.7
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.183.0/containers/python-3/.devcontainer/base.Dockerfile
 
 # [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6
-ARG VARIANT="3.9"
+ARG VARIANT="3.7"
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
 # Prevents Python from writing .pyc files to disk.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ DESCRIPTION = 'A companion module for the UoP SDB seagrass project.'
 URL = 'https://github.com/Max-FM/seagrass'
 EMAIL = 'max.foxley-marrable@port.ac.uk'
 AUTHOR = 'Max Foxley-Marrable, Andrew Lundgren'
-REQUIRES_PYTHON = '>=3.6.0'
+REQUIRES_PYTHON = '>=3.6.0, <3.8'
 VERSION = '0.1.0'
 
 # What packages are required for this module to be executed?


### PR DESCRIPTION
PR changes required Python version to >=3.6, <3.8 to work with Modulos prediction software.